### PR TITLE
Custom image

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+import os
+import shutil
+import sys
+import warnings
+
+from django.core.management import execute_from_command_line
+
+os.environ['DJANGO_SETTINGS_MODULE'] = 'wagtail_embed_videos.tests.settings'
+
+
+def runtests():
+    # Don't ignore DeprecationWarnings
+    warnings.simplefilter('default', DeprecationWarning)
+    warnings.simplefilter('default', PendingDeprecationWarning)
+
+    args = sys.argv[1:]
+
+    if '--postgres' in args:
+        os.environ['DATABASE_ENGINE'] = 'django.db.backends.postgresql_psycopg2'
+        args.remove('--postgres')
+
+    if '--elasticsearch' in args:
+        os.environ.setdefault('ELASTICSEARCH_URL', 'http://localhost:9200')
+        args.remove('--elasticsearch')
+
+    argv = sys.argv[:1] + ['test'] + args
+    try:
+        execute_from_command_line(argv)
+    finally:
+        from wagtail.tests.settings import STATIC_ROOT, MEDIA_ROOT
+        shutil.rmtree(STATIC_ROOT, ignore_errors=True)
+        shutil.rmtree(MEDIA_ROOT, ignore_errors=True)
+
+
+if __name__ == '__main__':
+    runtests()

--- a/wagtail_embed_videos/models.py
+++ b/wagtail_embed_videos/models.py
@@ -50,7 +50,8 @@ YOUTUBE_RESOLUTIONS = [
 
 
 def create_thumbnail(model_instance):
-    from wagtail.wagtailimages.models import get_image_model  # http://stackoverflow.com/a/25648427/1179222
+    # http://stackoverflow.com/a/25648427/1179222
+    from wagtail.wagtailimages.models import get_image_model
     WagtailImage = get_image_model()
 
     # CREATING IMAGE FROM THUMBNAIL

--- a/wagtail_embed_videos/models.py
+++ b/wagtail_embed_videos/models.py
@@ -21,7 +21,6 @@ from django.core.files.temp import NamedTemporaryFile
 from wagtail.wagtailadmin.taggable import TagSearchable
 from wagtail.wagtailadmin.utils import get_object_usage
 from wagtail.wagtailsearch import index
-from wagtail.wagtailimages.models import Image as WagtailImage
 
 from embed_video.fields import EmbedVideoField
 from embed_video.backends import detect_backend
@@ -31,6 +30,11 @@ try:
     get_model = apps.get_model
 except ImportError:
     from django.db.models.loading import get_model
+
+try:
+    image_model_name = settings.WAGTAILIMAGES_IMAGE_MODEL
+except AttributeError:
+    image_model_name = 'wagtailimages.Image'
 
 
 def checkUrl(url):
@@ -46,6 +50,9 @@ YOUTUBE_RESOLUTIONS = [
 
 
 def create_thumbnail(model_instance):
+    from wagtail.wagtailimages.models import get_image_model  # http://stackoverflow.com/a/25648427/1179222
+    WagtailImage = get_image_model()
+
     # CREATING IMAGE FROM THUMBNAIL
     backend = detect_backend(model_instance.url)
     thumbnail_url = backend.get_thumbnail_url()
@@ -79,7 +86,7 @@ class AbstractEmbedVideo(models.Model, TagSearchable):
     title = models.CharField(max_length=255, verbose_name=_('Title'))
     url = EmbedVideoField()
     thumbnail = models.ForeignKey(
-        'wagtailimages.Image',
+        image_model_name,
         verbose_name="Thumbnail",
         null=True,
         blank=True,

--- a/wagtail_embed_videos/tests/settings.py
+++ b/wagtail_embed_videos/tests/settings.py
@@ -1,0 +1,149 @@
+import os
+
+WAGTAIL_ROOT = os.path.dirname(__file__)
+STATIC_ROOT = os.path.join(WAGTAIL_ROOT, 'test-static')
+MEDIA_ROOT = os.path.join(WAGTAIL_ROOT, 'test-media')
+MEDIA_URL = '/media/'
+
+
+DATABASES = {
+    'default': {
+        'ENGINE': os.environ.get('DATABASE_ENGINE', 'django.db.backends.sqlite3'),
+        'NAME': os.environ.get('DATABASE_NAME', 'wagtail'),
+        'USER': os.environ.get('DATABASE_USER', None),
+        'PASSWORD': os.environ.get('DATABASE_PASS', None),
+        'HOST': os.environ.get('DATABASE_HOST', None),
+
+        'TEST': {
+            'NAME': os.environ.get('DATABASE_NAME', None),
+        }
+    }
+}
+
+
+SECRET_KEY = 'not needed'
+
+ROOT_URLCONF = 'wagtail.tests.urls'
+
+STATIC_URL = '/static/'
+STATIC_ROOT = STATIC_ROOT
+
+STATICFILES_FINDERS = (
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    'compressor.finders.CompressorFinder',
+)
+
+USE_TZ = True
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+                'django.template.context_processors.request',
+                'wagtail.tests.context_processors.do_not_use_static_url',
+                'wagtail.contrib.settings.context_processors.settings',
+            ],
+        },
+    },
+    {
+        'BACKEND': 'django.template.backends.jinja2.Jinja2',
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'extensions': [
+                'wagtail.wagtailcore.jinja2tags.core',
+                'wagtail.wagtailadmin.jinja2tags.userbar',
+                'wagtail.wagtailimages.jinja2tags.images',
+            ],
+        },
+    },
+]
+
+MIDDLEWARE_CLASSES = (
+    'django.middleware.common.CommonMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+
+    'wagtail.wagtailcore.middleware.SiteMiddleware',
+
+    'wagtail.wagtailredirects.middleware.RedirectMiddleware',
+)
+
+INSTALLED_APPS = (
+    # Install wagtailredirects with its appconfig
+    # Theres nothing special about wagtailredirects, we just need to have one
+    # app which uses AppConfigs to test that hooks load properly
+    'wagtail.wagtailforms',
+    'wagtail.wagtailredirects',
+    'wagtail.wagtailembeds',
+    'wagtail.wagtailsites',
+    'wagtail.wagtailusers',
+    'wagtail.wagtailsnippets',
+    'wagtail.wagtaildocs',
+    'wagtail.wagtailimages',
+    'wagtail.wagtailsearch',
+    'wagtail.wagtailadmin',
+    'wagtail.wagtailcore',
+    'wagtail.contrib.wagtailapi',
+
+    'modelcluster',
+    'compressor',
+    'taggit',
+    'rest_framework',
+
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+
+    'embed_video',
+    'wagtail_embed_videos',
+)
+
+
+# Using DatabaseCache to make sure that the cache is cleared between tests.
+# This prevents false-positives in some wagtail core tests where we are
+# changing the 'wagtail_root_paths' key which may cause future tests to fail.
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+        'LOCATION': 'cache',
+    }
+}
+
+PASSWORD_HASHERS = (
+    'django.contrib.auth.hashers.MD5PasswordHasher',  # don't use the intentionally slow default password hasher
+)
+
+COMPRESS_ENABLED = False  # disable compression so that we can run tests on the content of the compress tag
+
+
+WAGTAILSEARCH_BACKENDS = {
+    'default': {
+        'BACKEND': 'wagtail.wagtailsearch.backends.db',
+    }
+}
+
+if 'ELASTICSEARCH_URL' in os.environ:
+    WAGTAILSEARCH_BACKENDS['elasticsearch'] = {
+        'BACKEND': 'wagtail.wagtailsearch.backends.elasticsearch',
+        'URLS': [os.environ['ELASTICSEARCH_URL']],
+        'TIMEOUT': 10,
+        'max_retries': 1,
+        'AUTO_UPDATE': False,
+    }
+
+
+WAGTAIL_SITE_NAME = "Test Site"

--- a/wagtail_embed_videos/tests/test_model.py
+++ b/wagtail_embed_videos/tests/test_model.py
@@ -1,0 +1,39 @@
+import sys
+
+from django.conf import settings
+from django.test import TestCase
+
+
+class EmbedVideoTestCase(TestCase):
+    def setUp(self):
+        pass
+
+    def test_video_image_model(self):
+        """Image model is the default Wagtail model"""
+        # Remove module from cache
+        # (https://docs.python.org/3/reference/import.html#the-module-cache)
+        try:
+            del sys.modules['wagtail_embed_videos.models']
+        except KeyError:
+            pass  # Nothing to do
+
+        # Thumbnail model is set dynamically at import.
+        from wagtail_embed_videos.models import image_model_name
+
+        self.assertEqual(image_model_name, 'wagtailimages.Image')
+
+    def test_custom_image_model(self):
+        """Image model is a custom model"""
+        with self.settings(
+                WAGTAILIMAGES_IMAGE_MODEL='testapp.CustomImage'):
+            try:
+                del sys.modules['wagtail_embed_videos.models']
+            except KeyError:
+                pass  # Nothing to do
+
+            from wagtail_embed_videos.models import image_model_name
+
+            self.assertEqual(settings.WAGTAILIMAGES_IMAGE_MODEL,
+                             'testapp.CustomImage')
+            self.assertEqual(image_model_name,
+                             'testapp.CustomImage')


### PR DESCRIPTION
Adds support for a custom image model. If using a custom image model, after adding wagtail_embed_videos to `INSTALLED_APPS`, users will have to run `./manage.py makemigrations && ./manage.py migrate` to migrate the thumbnail field to the new image model.
