### PR TITLE
Wagtail 1.7 compatibilitie fix

### DIFF
--- a/wagtail_embed_videos/models.py
+++ b/wagtail_embed_videos/models.py
@@ -100,9 +100,9 @@ class AbstractEmbedVideo(models.Model, TagSearchable):
         return reverse('wagtail_embed_videos_video_usage',
                        args=(self.id,))
 
-    search_fields = TagSearchable.search_fields + (
+    search_fields = TagSearchable.search_fields + [
         index.FilterField('uploaded_by_user'),
-    )
+    ]
 
     def __str__(self):
         return self.title


### PR DESCRIPTION
Following the [documentation](http://docs.wagtail.io/en/v1.6.2/releases/1.5.html?highlight=search_field#the-search-fields-attribute-on-models-should-now-be-set-to-a-list), make this change for fix this warning:

``` bash
/home/salahaddin/Proyectos/uzman/lib/python3.5/site-packages/wagtail_embed_videos/models.py:104: RemovedInWagtail17Warning: Using a tuple for search_fields on TagSearchable subclasses is deprecated, use a list instead
  index.FilterField('uploaded_by_user'),
/home/salahaddin/Proyectos/uzman/lib/python3.5/site-packages/wagtail_embed_videos/models.py:104: RemovedInWagtail17Warning: Using a tuple for search_fields on TagSearchable subclasses is deprecated, use a list instead
  index.FilterField('uploaded_by_user'),
```
