### PR TITLE
render_basic method needs context keyword argument

### DIFF
--- a/wagtail_embed_videos/blocks.py
+++ b/wagtail_embed_videos/blocks.py
@@ -13,7 +13,7 @@ class EmbedVideoChooserBlock(ChooserBlock):
         from wagtail_embed_videos.widgets import AdminEmbedVideoChooser
         return AdminEmbedVideoChooser
 
-    def render_basic(self, value):
+    def render_basic(self, value, context=None):
         if value:
             return VideoNode.embed(value.url, size = 'medium')
         else:


### PR DESCRIPTION
http://docs.wagtail.io/en/v1.9/releases/1.6.html#render-and-render-basic-methods-on-streamfield-blocks-now-accept-a-context-keyword-argument