### PR TITLE
Fix for pagination change on Wagtail > 2.5

### DIFF
--- a/wagtail_embed_videos/templates/wagtail_embed_videos/chooser/results.html
+++ b/wagtail_embed_videos/templates/wagtail_embed_videos/chooser/results.html
@@ -32,5 +32,5 @@
         {% endfor %}
     </ul>
 
-    {% include "wagtailadmin/shared/pagination_nav.html" with items=embed_videos is_ajax=1 %}
+    {% include "wagtailadmin/shared/ajax_pagination_nav.html" with items=embed_videos %}
 {% endif %}


### PR DESCRIPTION
`{% include "wagtailadmin/shared/pagination_nav.html" with items=page_obj is_ajax=1 %}
`

should become

`{% include "wagtailadmin/shared/ajax_pagination_nav.html" with items=page_obj %}
`

https://docs.wagtail.io/en/v2.7/releases/2.5.html#changes-to-admin-pagination-helpers